### PR TITLE
query-data-order

### DIFF
--- a/backend/src/main/java/org/yellowcat/backend/product/order/OrderController.java
+++ b/backend/src/main/java/org/yellowcat/backend/product/order/OrderController.java
@@ -3,10 +3,13 @@ package org.yellowcat.backend.product.order;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.yellowcat.backend.common.config_api.response.PageResponse;
 import org.yellowcat.backend.common.config_api.response.ResponseEntityBuilder;
+import org.yellowcat.backend.product.order.dto.OrderResponse;
 import org.yellowcat.backend.product.order.dto.OrderUpdateRequest;
 import org.yellowcat.backend.product.order.dto.OrderUpdateResponse;
 
@@ -16,6 +19,30 @@ import org.yellowcat.backend.product.order.dto.OrderUpdateResponse;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class OrderController {
     OrderService orderService;
+
+    @GetMapping()
+    @PreAuthorize("hasAnyAuthority('Admin_Web', 'Staff_Web')")
+    public ResponseEntity<?> getOrders(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<OrderResponse> orders = orderService.getOrders(page, size);
+        PageResponse<OrderResponse> pageResponse = new PageResponse<>(orders);
+
+        return ResponseEntityBuilder.success(pageResponse);
+    }
+
+    @GetMapping("/status")
+    @PreAuthorize("hasAnyAuthority('Admin_Web', 'Staff_Web')")
+    public ResponseEntity<?> getOrderByStatus(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<OrderResponse> orders = orderService.getOrderByStatus(page, size);
+        PageResponse<OrderResponse> pageResponse = new PageResponse<>(orders);
+
+        return ResponseEntityBuilder.success(pageResponse);
+    }
 
     @PostMapping
     @PreAuthorize("hasAnyAuthority('Admin_Web', 'Staff_Web')")

--- a/backend/src/main/java/org/yellowcat/backend/product/order/OrderRepository.java
+++ b/backend/src/main/java/org/yellowcat/backend/product/order/OrderRepository.java
@@ -1,12 +1,46 @@
 package org.yellowcat.backend.product.order;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.yellowcat.backend.product.order.dto.OrderResponse;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Integer> {
     @Query("SELECT o FROM Order o WHERE o.orderId = :orderId")
     Order findByIdFetchAll(@Param("orderId") Integer orderId);
+
+    @Query(nativeQuery = true,
+            value = "SELECT " +
+                    "o.order_id AS orderId, " +
+                    "o.order_code AS orderCode, " +
+                    "o.phone_number AS phoneNumber, " +
+                    "o.customer_name AS customerName, " +
+                    "o.sub_total_amount AS subTotalAmount, " +
+                    "o.discount_amount AS discountAmount, " +
+                    "o.final_amount AS finalAmount, " +
+                    "o.order_status AS orderStatus " +
+                    "FROM orders o " +
+                    "ORDER BY o.order_date DESC"
+    )
+    Page<OrderResponse> findAllOrders(Pageable pageable);
+
+    @Query(nativeQuery = true,
+            value = "SELECT " +
+                    "o.order_id AS orderId, " +
+                    "o.order_code AS orderCode, " +
+                    "o.phone_number AS phoneNumber, " +
+                    "o.customer_name AS customerName, " +
+                    "o.sub_total_amount AS subTotalAmount, " +
+                    "o.discount_amount AS discountAmount, " +
+                    "o.final_amount AS finalAmount, " +
+                    "o.order_status AS orderStatus " +
+                    "FROM orders o " +
+                    "WHERE o.order_status = :orderStatus " +
+                    "ORDER BY o.order_date DESC"
+    )
+    Page<OrderResponse> findAllByOrderStatus(String orderStatus, Pageable pageable);
 }

--- a/backend/src/main/java/org/yellowcat/backend/product/order/OrderService.java
+++ b/backend/src/main/java/org/yellowcat/backend/product/order/OrderService.java
@@ -3,7 +3,11 @@ package org.yellowcat.backend.product.order;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.yellowcat.backend.product.order.dto.OrderResponse;
 import org.yellowcat.backend.product.order.dto.OrderUpdateRequest;
 import org.yellowcat.backend.product.order.dto.OrderUpdateResponse;
 import org.yellowcat.backend.product.order.mapper.OrderMapper;
@@ -24,6 +28,19 @@ public class OrderService {
     OrderItemRepository orderItemRepository;
     PaymentRepository paymentRepository;
     OrderMapper orderMapper;
+
+    public Page<OrderResponse> getOrders(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        return orderRepository.findAllOrders(pageable);
+    }
+
+    public Page<OrderResponse> getOrderByStatus(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        String orderStatus = "Pending";
+
+        return orderRepository.findAllByOrderStatus(orderStatus, pageable);
+    }
 
     public OrderUpdateResponse updateOrder(OrderUpdateRequest request) {
         // Lấy danh sách OrderItem theo orderId

--- a/backend/src/main/java/org/yellowcat/backend/product/order/dto/OrderResponse.java
+++ b/backend/src/main/java/org/yellowcat/backend/product/order/dto/OrderResponse.java
@@ -1,0 +1,19 @@
+package org.yellowcat.backend.product.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@AllArgsConstructor
+@Getter
+public class OrderResponse {
+    Integer orderId;
+    String orderCode;
+    String phoneNumber;
+    String customerName;
+    BigDecimal subTotalAmount;
+    BigDecimal discountAmount;
+    BigDecimal finalAmount;
+    String orderStatus;
+}

--- a/backend/src/main/java/org/yellowcat/backend/product/orderItem/OrderItemController.java
+++ b/backend/src/main/java/org/yellowcat/backend/product/orderItem/OrderItemController.java
@@ -3,9 +3,11 @@ package org.yellowcat.backend.product.orderItem;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.yellowcat.backend.common.config_api.response.PageResponse;
 import org.yellowcat.backend.common.config_api.response.ResponseEntityBuilder;
 import org.yellowcat.backend.product.orderItem.dto.OrderItemCreatedRequest;
 import org.yellowcat.backend.product.orderItem.dto.OrderItemResponse;
@@ -17,6 +19,19 @@ import org.yellowcat.backend.product.orderItem.dto.UpdateOrderItemQuantityReques
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class OrderItemController {
     OrderItemService orderItemService;
+
+    @GetMapping()
+    @PreAuthorize("hasAnyAuthority('Admin_Web', 'Staff_Web')")
+    public ResponseEntity<?> getOrderItemsByOrderId(
+            @RequestParam Integer orderId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<OrderItemResponse> orderItems = orderItemService.getOrderItemsByOrderId(orderId, page, size);
+        PageResponse<OrderItemResponse> pageResponse = new PageResponse<>(orderItems);
+
+        return ResponseEntityBuilder.success(pageResponse);
+    }
 
     @PostMapping
     @PreAuthorize("hasAnyAuthority('Admin_Web', 'Staff_Web')")

--- a/backend/src/main/java/org/yellowcat/backend/product/orderItem/OrderItemRepository.java
+++ b/backend/src/main/java/org/yellowcat/backend/product/orderItem/OrderItemRepository.java
@@ -1,5 +1,7 @@
 package org.yellowcat.backend.product.orderItem;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +15,6 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Integer> {
 
     @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.order WHERE oi.orderItemId = :id")
     OrderItem findByIdWithOrder(@Param("id") Integer id);
+
+    Page<OrderItem> findByOrder_OrderId(Integer orderId, Pageable pageable);
 }

--- a/backend/src/main/java/org/yellowcat/backend/product/orderItem/OrderItemService.java
+++ b/backend/src/main/java/org/yellowcat/backend/product/orderItem/OrderItemService.java
@@ -3,6 +3,10 @@ package org.yellowcat.backend.product.orderItem;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.yellowcat.backend.product.order.Order;
 import org.yellowcat.backend.product.order.OrderRepository;
@@ -24,6 +28,14 @@ public class OrderItemService {
     OrderRepository orderRepository;
     ProductVariantRepository productVariantRepository;
     OrderItemMapper orderItemMapper;
+
+    public Page<OrderItemResponse> getOrderItemsByOrderId(Integer orderId, int page, int size) {
+        Sort sort = Sort.by("priceAtPurchase").descending();
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<OrderItem> orderItems = orderItemRepository.findByOrder_OrderId(orderId, pageable);
+
+        return orderItems.map(orderItemMapper::toOrderItemResponse);
+    }
 
     public OrderItemResponse createOrderItem(OrderItemCreatedRequest request) {
         Order order = orderRepository.findById(request.getOrderId())


### PR DESCRIPTION
- Created API GET("/api/orders"): To display the order list
- Created API GET("/api/orders/status"): To display the order list by orderStatus
- Created API GET("/api/order-items"): To display the order item list by orderId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added endpoints to retrieve paginated lists of orders and filter orders by status.
  - Introduced a new endpoint to fetch paginated order items by order ID.
  - Responses for order and order item lists now include detailed information in a standardized format.

- **Improvements**
  - Enhanced support for pagination when viewing orders and order items, improving navigation for large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->