### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nongtiensonpro/Yellow_Cat_Web/security/code-scanning/4](https://github.com/nongtiensonpro/Yellow_Cat_Web/security/code-scanning/4)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for most steps, as the workflow primarily involves checking out code, installing dependencies, and building the frontend and backend. If the workflow needs to interact with pull requests or other resources, additional permissions can be added as needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build`) to limit permissions for that job only. In this case, adding it at the root level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to specify repository permissions for build checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->