### PR TITLE
Add promotion order management pages and menu link

### DIFF
--- a/fontend/app/admin/promotion_order/[id]/page.tsx
+++ b/fontend/app/admin/promotion_order/[id]/page.tsx
@@ -1,0 +1,530 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter, useParams } from 'next/navigation';
+import { Session } from 'next-auth';
+import Link from 'next/link';
+
+interface CustomSession extends Session {
+    accessToken?: string;
+}
+
+interface PromotionOrder {
+    promotionProgramId: number;
+    promotionCode: string;
+    promotionName: string;
+    description: string;
+    discountType: string;
+    discountValue: string;
+    startDate: string;
+    endDate: string;
+    isActive: boolean;
+    minimumOrderValue: string;
+    usageLimitPerUser: number;
+    usageLimitTotal: number;
+    createdBy: string;
+    updatedBy: string;
+    createdAt: string;
+}
+
+interface PromotionOrderRequest {
+    promotionName: string;
+    description: string;
+    discountType: string;
+    discountValue: string;
+    startDate: string;
+    endDate: string;
+    isActive: boolean;
+    minimumOrderValue: string;
+    usageLimitPerUser: number;
+    usageLimitTotal: number;
+}
+
+export default function EditPromotionOrderPage() {
+    const { data: session, status: sessionStatus } = useSession() as { data: CustomSession | null; status: string };
+    const router = useRouter();
+    const params = useParams();
+    const promotionId = params.id as string;
+    const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+    
+    const [promotion, setPromotion] = useState<PromotionOrder | null>(null);
+    const [formData, setFormData] = useState<PromotionOrderRequest>({
+        promotionName: '',
+        description: '',
+        discountType: 'VNĐ',
+        discountValue: '',
+        startDate: '',
+        endDate: '',
+        isActive: true,
+        minimumOrderValue: '',
+        usageLimitPerUser: 1,
+        usageLimitTotal: 0
+    });
+
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [loading, setLoading] = useState(false);
+    const [dataLoading, setDataLoading] = useState(true);
+
+    // Load promotion data
+    useEffect(() => {
+        const loadPromotionData = async () => {
+            if (sessionStatus !== 'authenticated' || !session?.accessToken) return;
+            
+            try {
+                const response = await fetch(`${API_URL}/api/promotion-orders/${promotionId}`, {
+                    headers: { Authorization: `Bearer ${session.accessToken}` }
+                });
+
+                if (!response.ok) {
+                    throw new Error('Không thể tải dữ liệu chương trình khuyến mãi');
+                }
+
+                const data = await response.json();
+                const promotionData = data.data || data;
+                
+                setPromotion(promotionData);
+                setFormData({
+                    promotionName: promotionData.promotionName || '',
+                    description: promotionData.description || '',
+                    discountType: promotionData.discountType || 'VNĐ',
+                    discountValue: promotionData.discountValue || '',
+                    startDate: promotionData.startDate ? promotionData.startDate.slice(0, 16) : '',
+                    endDate: promotionData.endDate ? promotionData.endDate.slice(0, 16) : '',
+                    isActive: promotionData.isActive !== undefined ? promotionData.isActive : true,
+                    minimumOrderValue: promotionData.minimumOrderValue || '',
+                    usageLimitPerUser: promotionData.usageLimitPerUser || 1,
+                    usageLimitTotal: promotionData.usageLimitTotal || 0
+                });
+            } catch (error) {
+                console.error('Error loading promotion data:', error);
+                alert('Không thể tải dữ liệu chương trình khuyến mãi');
+                router.push('/admin/promotion_order');
+            } finally {
+                setDataLoading(false);
+            }
+        };
+
+        if (promotionId) {
+            loadPromotionData();
+        }
+    }, [promotionId, session, sessionStatus, API_URL, router]);
+
+    const validateForm = (): boolean => {
+        const newErrors: Record<string, string> = {};
+
+        if (!formData.promotionName.trim()) {
+            newErrors.promotionName = 'Tên chương trình khuyến mãi là bắt buộc';
+        }
+
+        if (!formData.description.trim()) {
+            newErrors.description = 'Mô tả là bắt buộc';
+        }
+
+        if (!formData.discountType) {
+            newErrors.discountType = 'Loại giảm giá là bắt buộc';
+        }
+
+        if (formData.discountType !== 'free_shipping' && !formData.discountValue.trim()) {
+            newErrors.discountValue = 'Giá trị giảm giá là bắt buộc';
+        }
+
+        if (formData.discountType === 'VNĐ' || formData.discountType === 'fixed_amount') {
+            const value = parseFloat(formData.discountValue);
+            if (isNaN(value) || value <= 0) {
+                newErrors.discountValue = 'Giá trị giảm giá phải là số dương';
+            }
+        }
+
+        if (formData.discountType === 'percentage' || formData.discountType === '%') {
+            const value = parseFloat(formData.discountValue);
+            if (isNaN(value) || value <= 0 || value > 100) {
+                newErrors.discountValue = 'Phần trăm giảm giá phải từ 1-100%';
+            }
+        }
+
+        if (!formData.startDate) {
+            newErrors.startDate = 'Ngày bắt đầu là bắt buộc';
+        }
+
+        if (!formData.endDate) {
+            newErrors.endDate = 'Ngày kết thúc là bắt buộc';
+        }
+
+        if (formData.startDate && formData.endDate) {
+            const startDate = new Date(formData.startDate);
+            const endDate = new Date(formData.endDate);
+            if (startDate >= endDate) {
+                newErrors.endDate = 'Ngày kết thúc phải sau ngày bắt đầu';
+            }
+        }
+
+        if (!formData.minimumOrderValue.trim()) {
+            newErrors.minimumOrderValue = 'Giá trị đơn hàng tối thiểu là bắt buộc';
+        } else {
+            const value = parseFloat(formData.minimumOrderValue);
+            if (isNaN(value) || value < 0) {
+                newErrors.minimumOrderValue = 'Giá trị đơn hàng tối thiểu phải là số không âm';
+            }
+        }
+
+        if (formData.usageLimitPerUser < 1) {
+            newErrors.usageLimitPerUser = 'Giới hạn sử dụng mỗi người phải >= 1';
+        }
+
+        if (formData.usageLimitTotal < 0) {
+            newErrors.usageLimitTotal = 'Giới hạn tổng phải >= 0';
+        }
+
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        
+        if (!validateForm()) return;
+        if (sessionStatus !== 'authenticated' || !session?.accessToken) {
+            alert('Vui lòng đăng nhập để cập nhật chương trình khuyến mãi');
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const response = await fetch(`${API_URL}/api/promotion-orders/${promotionId}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${session.accessToken}`
+                },
+                body: JSON.stringify(formData)
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.message || 'Có lỗi xảy ra khi cập nhật chương trình khuyến mãi');
+            }
+
+            alert('✅ Cập nhật chương trình khuyến mãi thành công!');
+            router.push('/admin/promotion_order');
+        } catch (error) {
+            console.error('Error updating promotion order:', error);
+            alert(`❌ Lỗi: ${error instanceof Error ? error.message : 'Có lỗi xảy ra'}`);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleInputChange = (field: keyof PromotionOrderRequest, value: string | number | boolean) => {
+        setFormData(prev => ({
+            ...prev,
+            [field]: value
+        }));
+        
+        // Clear error when user starts typing
+        if (errors[field]) {
+            setErrors(prev => ({
+                ...prev,
+                [field]: ''
+            }));
+        }
+    };
+
+    const isExpired = () => {
+        if (!promotion) return false;
+        const now = new Date();
+        const endDate = new Date(promotion.endDate);
+        return now > endDate;
+    };
+
+    if (dataLoading) {
+        return (
+            <div className="p-6 bg-gray-50 min-h-screen flex items-center justify-center">
+                <div className="flex items-center gap-2">
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600" />
+                    <span className="text-gray-600">Đang tải dữ liệu...</span>
+                </div>
+            </div>
+        );
+    }
+
+    if (!promotion) {
+        return (
+            <div className="p-6 bg-gray-50 min-h-screen">
+                <div className="text-center">
+                    <p className="text-gray-500">Không tìm thấy chương trình khuyến mãi</p>
+                    <Link href="/admin/promotion_order" className="text-blue-500 hover:underline">
+                        Quay lại danh sách
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="p-6 bg-gray-50 min-h-screen">
+            <div className="max-w-4xl mx-auto">
+                <div className="flex items-center justify-between mb-6">
+                    <h1 className="text-2xl font-bold text-gray-800">Chỉnh sửa Chương trình Khuyến mãi</h1>
+                    <Link
+                        href="/admin/promotion_order"
+                        className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+                    >
+                        ← Quay lại
+                    </Link>
+                </div>
+
+                {/* Thông tin cơ bản */}
+                <div className="bg-white rounded-lg shadow p-6 mb-6">
+                    <h2 className="text-lg font-semibold text-gray-800 mb-4">Thông tin cơ bản</h2>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                        <div>
+                            <span className="font-medium text-gray-600">Mã khuyến mãi:</span>
+                            <span className="ml-2 font-mono bg-gray-100 px-2 py-1 rounded">
+                                {promotion.promotionCode}
+                            </span>
+                        </div>
+                        <div>
+                            <span className="font-medium text-gray-600">Người tạo:</span>
+                            <span className="ml-2">{promotion.createdBy}</span>
+                        </div>
+                        <div>
+                            <span className="font-medium text-gray-600">Người cập nhật:</span>
+                            <span className="ml-2">{promotion.updatedBy}</span>
+                        </div>
+                        <div>
+                            <span className="font-medium text-gray-600">Ngày tạo:</span>
+                            <span className="ml-2">
+                                {new Date(promotion.createdAt).toLocaleString('vi-VN')}
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="bg-white rounded-lg shadow p-6">
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            {/* Tên chương trình */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Tên chương trình khuyến mãi *
+                                </label>
+                                <input
+                                    type="text"
+                                    value={formData.promotionName}
+                                    onChange={(e) => handleInputChange('promotionName', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.promotionName ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Nhập tên chương trình khuyến mãi"
+                                />
+                                {errors.promotionName && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.promotionName}</p>
+                                )}
+                            </div>
+
+                            {/* Mô tả */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Mô tả *
+                                </label>
+                                <input
+                                    type="text"
+                                    value={formData.description}
+                                    onChange={(e) => handleInputChange('description', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.description ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Mô tả chương trình khuyến mãi"
+                                />
+                                {errors.description && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.description}</p>
+                                )}
+                            </div>
+
+                            {/* Loại giảm giá */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Loại giảm giá *
+                                </label>
+                                <select
+                                    value={formData.discountType}
+                                    onChange={(e) => handleInputChange('discountType', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.discountType ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                >
+                                    <option value="VNĐ">Giảm giá cố định (VNĐ)</option>
+                                    <option value="percentage">Giảm giá theo phần trăm (%)</option>
+                                    <option value="free_shipping">Miễn phí vận chuyển</option>
+                                </select>
+                                {errors.discountType && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.discountType}</p>
+                                )}
+                            </div>
+
+                            {/* Giá trị giảm giá */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Giá trị giảm giá *
+                                </label>
+                                <input
+                                    type="number"
+                                    value={formData.discountValue}
+                                    onChange={(e) => handleInputChange('discountValue', e.target.value)}
+                                    disabled={formData.discountType === 'free_shipping'}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.discountValue ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    } ${formData.discountType === 'free_shipping' ? 'bg-gray-100' : ''}`}
+                                    placeholder={formData.discountType === 'percentage' ? 'Nhập phần trăm (1-100)' : 'Nhập giá trị'}
+                                    min={formData.discountType === 'percentage' ? '1' : '0'}
+                                    max={formData.discountType === 'percentage' ? '100' : undefined}
+                                />
+                                {errors.discountValue && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.discountValue}</p>
+                                )}
+                            </div>
+
+                            {/* Giá trị đơn hàng tối thiểu */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Giá trị đơn hàng tối thiểu (VNĐ) *
+                                </label>
+                                <input
+                                    type="number"
+                                    value={formData.minimumOrderValue}
+                                    onChange={(e) => handleInputChange('minimumOrderValue', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.minimumOrderValue ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Nhập giá trị tối thiểu"
+                                    min="0"
+                                />
+                                {errors.minimumOrderValue && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.minimumOrderValue}</p>
+                                )}
+                            </div>
+
+                            {/* Giới hạn sử dụng mỗi người */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Giới hạn sử dụng mỗi người
+                                </label>
+                                <input
+                                    type="number"
+                                    value={formData.usageLimitPerUser}
+                                    onChange={(e) => handleInputChange('usageLimitPerUser', parseInt(e.target.value) || 1)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.usageLimitPerUser ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Số lần sử dụng tối đa mỗi người"
+                                    min="1"
+                                />
+                                {errors.usageLimitPerUser && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.usageLimitPerUser}</p>
+                                )}
+                            </div>
+
+                            {/* Giới hạn tổng */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Giới hạn tổng (0 = không giới hạn)
+                                </label>
+                                <input
+                                    type="number"
+                                    value={formData.usageLimitTotal}
+                                    onChange={(e) => handleInputChange('usageLimitTotal', parseInt(e.target.value) || 0)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.usageLimitTotal ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Tổng số lần sử dụng tối đa"
+                                    min="0"
+                                />
+                                {errors.usageLimitTotal && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.usageLimitTotal}</p>
+                                )}
+                            </div>
+
+                            {/* Ngày bắt đầu */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Ngày bắt đầu *
+                                </label>
+                                <input
+                                    type="datetime-local"
+                                    value={formData.startDate}
+                                    onChange={(e) => handleInputChange('startDate', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.startDate ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                />
+                                {errors.startDate && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.startDate}</p>
+                                )}
+                            </div>
+
+                            {/* Ngày kết thúc */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Ngày kết thúc *
+                                </label>
+                                <input
+                                    type="datetime-local"
+                                    value={formData.endDate}
+                                    onChange={(e) => handleInputChange('endDate', e.target.value)}
+                                    min={formData.startDate}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.endDate ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                />
+                                {errors.endDate && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.endDate}</p>
+                                )}
+                            </div>
+
+                            {/* Trạng thái */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Trạng thái
+                                </label>
+                                <select
+                                    value={formData.isActive ? 'true' : 'false'}
+                                    onChange={(e) => handleInputChange('isActive', e.target.value === 'true')}
+                                    disabled={isExpired()}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        isExpired() ? 'bg-gray-100' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                >
+                                    <option value="true">Hoạt động</option>
+                                    <option value="false">Không hoạt động</option>
+                                </select>
+                                {isExpired() && (
+                                    <p className="text-yellow-600 text-sm mt-1">
+                                        Không thể thay đổi trạng thái của chương trình đã hết hạn
+                                    </p>
+                                )}
+                            </div>
+                        </div>
+
+                        {/* Nút submit */}
+                        <div className="flex justify-end gap-4 pt-6 border-t">
+                            <Link
+                                href="/admin/promotion_order"
+                                className="px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
+                            >
+                                Hủy
+                            </Link>
+                            <button
+                                type="submit"
+                                disabled={loading}
+                                className="px-6 py-2 bg-orange-500 text-white rounded-md hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {loading ? 'Đang cập nhật...' : 'Cập nhật chương trình khuyến mãi'}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    );
+} 

--- a/fontend/app/admin/promotion_order/create/page.tsx
+++ b/fontend/app/admin/promotion_order/create/page.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { Session } from 'next-auth';
+import Link from 'next/link';
+
+interface CustomSession extends Session {
+    accessToken?: string;
+}
+
+interface PromotionOrderRequest {
+    promotionName: string;
+    description: string;
+    discountType: string;
+    discountValue: string;
+    startDate: string;
+    endDate: string;
+    isActive: boolean;
+    minimumOrderValue: string;
+    usageLimitPerUser: number;
+    usageLimitTotal: number;
+}
+
+export default function CreatePromotionOrderPage() {
+    const { data: session, status: sessionStatus } = useSession() as { data: CustomSession | null; status: string };
+    const router = useRouter();
+    const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+    
+    const [formData, setFormData] = useState<PromotionOrderRequest>({
+        promotionName: '',
+        description: '',
+        discountType: 'VNĐ',
+        discountValue: '',
+        startDate: '',
+        endDate: '',
+        isActive: true,
+        minimumOrderValue: '',
+        usageLimitPerUser: 1,
+        usageLimitTotal: 0
+    });
+
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [loading, setLoading] = useState(false);
+
+    const validateForm = (): boolean => {
+        const newErrors: Record<string, string> = {};
+
+        if (!formData.promotionName.trim()) {
+            newErrors.promotionName = 'Tên chương trình khuyến mãi là bắt buộc';
+        }
+
+        if (!formData.description.trim()) {
+            newErrors.description = 'Mô tả là bắt buộc';
+        }
+
+        if (!formData.discountType) {
+            newErrors.discountType = 'Loại giảm giá là bắt buộc';
+        }
+
+        if (formData.discountType !== 'free_shipping' && !formData.discountValue.trim()) {
+            newErrors.discountValue = 'Giá trị giảm giá là bắt buộc';
+        }
+
+        if (formData.discountType === 'VNĐ' || formData.discountType === 'fixed_amount') {
+            const value = parseFloat(formData.discountValue);
+            if (isNaN(value) || value <= 0) {
+                newErrors.discountValue = 'Giá trị giảm giá phải là số dương';
+            }
+        }
+
+        if (formData.discountType === 'percentage' || formData.discountType === '%') {
+            const value = parseFloat(formData.discountValue);
+            if (isNaN(value) || value <= 0 || value > 100) {
+                newErrors.discountValue = 'Phần trăm giảm giá phải từ 1-100%';
+            }
+        }
+
+        if (!formData.startDate) {
+            newErrors.startDate = 'Ngày bắt đầu là bắt buộc';
+        }
+
+        if (!formData.endDate) {
+            newErrors.endDate = 'Ngày kết thúc là bắt buộc';
+        }
+
+        if (formData.startDate && formData.endDate) {
+            const startDate = new Date(formData.startDate);
+            const endDate = new Date(formData.endDate);
+            if (startDate >= endDate) {
+                newErrors.endDate = 'Ngày kết thúc phải sau ngày bắt đầu';
+            }
+        }
+
+        if (!formData.minimumOrderValue.trim()) {
+            newErrors.minimumOrderValue = 'Giá trị đơn hàng tối thiểu là bắt buộc';
+        } else {
+            const value = parseFloat(formData.minimumOrderValue);
+            if (isNaN(value) || value < 0) {
+                newErrors.minimumOrderValue = 'Giá trị đơn hàng tối thiểu phải là số không âm';
+            }
+        }
+
+        if (formData.usageLimitPerUser < 1) {
+            newErrors.usageLimitPerUser = 'Giới hạn sử dụng mỗi người phải >= 1';
+        }
+
+        if (formData.usageLimitTotal < 0) {
+            newErrors.usageLimitTotal = 'Giới hạn tổng phải >= 0';
+        }
+
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        
+        if (!validateForm()) return;
+        if (sessionStatus !== 'authenticated' || !session?.accessToken) {
+            alert('Vui lòng đăng nhập để tạo chương trình khuyến mãi');
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const response = await fetch(`${API_URL}/api/promotion-orders`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${session.accessToken}`
+                },
+                body: JSON.stringify(formData)
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.message || 'Có lỗi xảy ra khi tạo chương trình khuyến mãi');
+            }
+
+            alert('✅ Tạo chương trình khuyến mãi thành công!');
+            router.push('/admin/promotion_order');
+        } catch (error) {
+            console.error('Error creating promotion order:', error);
+            alert(`❌ Lỗi: ${error instanceof Error ? error.message : 'Có lỗi xảy ra'}`);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleInputChange = (field: keyof PromotionOrderRequest, value: string | number | boolean) => {
+        setFormData(prev => ({
+            ...prev,
+            [field]: value
+        }));
+        
+        // Clear error when user starts typing
+        if (errors[field]) {
+            setErrors(prev => ({
+                ...prev,
+                [field]: ''
+            }));
+        }
+    };
+
+    const getCurrentDateTime = () => {
+        const now = new Date();
+        return now.toISOString().slice(0, 16);
+    };
+
+    return (
+        <div className="p-6 bg-gray-50 min-h-screen">
+            <div className="max-w-4xl mx-auto">
+                <div className="flex items-center justify-between mb-6">
+                    <h1 className="text-2xl font-bold text-gray-800">Tạo Chương trình Khuyến mãi theo Hóa đơn</h1>
+                    <Link
+                        href="/admin/promotion_order"
+                        className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+                    >
+                        ← Quay lại
+                    </Link>
+                </div>
+
+                <div className="bg-white rounded-lg shadow p-6">
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            {/* Tên chương trình */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Tên chương trình khuyến mãi *
+                                </label>
+                                <input
+                                    type="text"
+                                    value={formData.promotionName}
+                                    onChange={(e) => handleInputChange('promotionName', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.promotionName ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Nhập tên chương trình khuyến mãi"
+                                />
+                                {errors.promotionName && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.promotionName}</p>
+                                )}
+                            </div>
+
+                            {/* Mô tả */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Mô tả *
+                                </label>
+                                <input
+                                    type="text"
+                                    value={formData.description}
+                                    onChange={(e) => handleInputChange('description', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.description ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Mô tả chương trình khuyến mãi"
+                                />
+                                {errors.description && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.description}</p>
+                                )}
+                            </div>
+
+                            {/* Loại giảm giá */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Loại giảm giá *
+                                </label>
+                                <select
+                                    value={formData.discountType}
+                                    onChange={(e) => handleInputChange('discountType', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.discountType ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                >
+                                    <option value="VNĐ">Giảm giá cố định (VNĐ)</option>
+                                    <option value="percentage">Giảm giá theo phần trăm (%)</option>
+                                    <option value="free_shipping">Miễn phí vận chuyển</option>
+                                </select>
+                                {errors.discountType && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.discountType}</p>
+                                )}
+                            </div>
+
+                            {/* Giá trị giảm giá */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Giá trị giảm giá *
+                                </label>
+                                <input
+                                    type="number"
+                                    value={formData.discountValue}
+                                    onChange={(e) => handleInputChange('discountValue', e.target.value)}
+                                    disabled={formData.discountType === 'free_shipping'}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.discountValue ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    } ${formData.discountType === 'free_shipping' ? 'bg-gray-100' : ''}`}
+                                    placeholder={formData.discountType === 'percentage' ? 'Nhập phần trăm (1-100)' : 'Nhập giá trị'}
+                                    min={formData.discountType === 'percentage' ? '1' : '0'}
+                                    max={formData.discountType === 'percentage' ? '100' : undefined}
+                                />
+                                {errors.discountValue && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.discountValue}</p>
+                                )}
+                            </div>
+
+                            {/* Giá trị đơn hàng tối thiểu */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Giá trị đơn hàng tối thiểu (VNĐ) *
+                                </label>
+                                <input
+                                    type="number"
+                                    value={formData.minimumOrderValue}
+                                    onChange={(e) => handleInputChange('minimumOrderValue', e.target.value)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.minimumOrderValue ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Nhập giá trị tối thiểu"
+                                    min="0"
+                                />
+                                {errors.minimumOrderValue && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.minimumOrderValue}</p>
+                                )}
+                            </div>
+
+                            {/* Giới hạn sử dụng mỗi người */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Giới hạn sử dụng mỗi người
+                                </label>
+                                <input
+                                    type="number"
+                                    value={formData.usageLimitPerUser}
+                                    onChange={(e) => handleInputChange('usageLimitPerUser', parseInt(e.target.value) || 1)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.usageLimitPerUser ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Số lần sử dụng tối đa mỗi người"
+                                    min="1"
+                                />
+                                {errors.usageLimitPerUser && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.usageLimitPerUser}</p>
+                                )}
+                            </div>
+
+                            {/* Giới hạn tổng */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Giới hạn tổng (0 = không giới hạn)
+                                </label>
+                                <input
+                                    type="number"
+                                    value={formData.usageLimitTotal}
+                                    onChange={(e) => handleInputChange('usageLimitTotal', parseInt(e.target.value) || 0)}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.usageLimitTotal ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                    placeholder="Tổng số lần sử dụng tối đa"
+                                    min="0"
+                                />
+                                {errors.usageLimitTotal && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.usageLimitTotal}</p>
+                                )}
+                            </div>
+
+                            {/* Ngày bắt đầu */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Ngày bắt đầu *
+                                </label>
+                                <input
+                                    type="datetime-local"
+                                    value={formData.startDate}
+                                    onChange={(e) => handleInputChange('startDate', e.target.value)}
+                                    min={getCurrentDateTime()}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.startDate ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                />
+                                {errors.startDate && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.startDate}</p>
+                                )}
+                            </div>
+
+                            {/* Ngày kết thúc */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Ngày kết thúc *
+                                </label>
+                                <input
+                                    type="datetime-local"
+                                    value={formData.endDate}
+                                    onChange={(e) => handleInputChange('endDate', e.target.value)}
+                                    min={formData.startDate || getCurrentDateTime()}
+                                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                                        errors.endDate ? 'border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-blue-500'
+                                    }`}
+                                />
+                                {errors.endDate && (
+                                    <p className="text-red-500 text-sm mt-1">{errors.endDate}</p>
+                                )}
+                            </div>
+
+                            {/* Trạng thái */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">
+                                    Trạng thái
+                                </label>
+                                <select
+                                    value={formData.isActive ? 'true' : 'false'}
+                                    onChange={(e) => handleInputChange('isActive', e.target.value === 'true')}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                >
+                                    <option value="true">Hoạt động</option>
+                                    <option value="false">Không hoạt động</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        {/* Nút submit */}
+                        <div className="flex justify-end gap-4 pt-6 border-t">
+                            <Link
+                                href="/admin/promotion_order"
+                                className="px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
+                            >
+                                Hủy
+                            </Link>
+                            <button
+                                type="submit"
+                                disabled={loading}
+                                className="px-6 py-2 bg-orange-500 text-white rounded-md hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {loading ? 'Đang tạo...' : 'Tạo chương trình khuyến mãi'}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    );
+} 

--- a/fontend/app/admin/promotion_order/page.tsx
+++ b/fontend/app/admin/promotion_order/page.tsx
@@ -1,0 +1,390 @@
+'use client';
+
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import Link from 'next/link';
+import { Edit, Trash2 } from 'lucide-react';
+import { useSession } from 'next-auth/react';
+import { Session } from 'next-auth';
+
+interface CustomSession extends Session {
+    accessToken?: string;
+}
+
+interface PromotionOrder {
+    promotionProgramId: number;
+    promotionCode: string;
+    promotionName: string;
+    description: string;
+    discountType: string;
+    discountValue: string;
+    startDate: string;
+    endDate: string;
+    isActive: boolean;
+    minimumOrderValue: string;
+    usageLimitPerUser: number;
+    usageLimitTotal: number;
+    createdBy: string;
+    updatedBy: string;
+    createdAt: string;
+}
+
+interface APIResponse {
+    data?: {
+        content: PromotionOrder[];
+        totalElements: number;
+        totalPages: number;
+        currentPage: number;
+    };
+    content?: PromotionOrder[];
+}
+
+function formatDiscount(value: string, type: string): string {
+    const numValue = parseFloat(value);
+    if (isNaN(numValue)) return '0';
+    
+    const t = type.toLowerCase();
+    if (t === 'percentage' || t === '%') return `${numValue}%`;
+    if (t === 'fixed' || t === 'fixed_amount' || t === 'vnđ') return `${numValue.toLocaleString()} ₫`;
+    if (t === 'free_shipping') return 'Miễn phí vận chuyển';
+    return `${numValue.toLocaleString()} ₫`;
+}
+
+function formatCurrency(value: string): string {
+    const numValue = parseFloat(value);
+    if (isNaN(numValue)) return '0 ₫';
+    return `${numValue.toLocaleString()} ₫`;
+}
+
+export default function PromotionOrderManagementPage() {
+    const [promotions, setPromotions] = useState<PromotionOrder[]>([]);
+    const [filters, setFilters] = useState({
+        keyword: '',
+        status: '',
+    });
+    const { data: session, status: sessionStatus } = useSession() as { data: CustomSession | null; status: string };
+    const [loading, setLoading] = useState(true);
+    const [currentPage, setCurrentPage] = useState(1);
+    const [totalPages, setTotalPages] = useState(1);
+    const itemsPerPage = 10;
+    const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
+    const handleDelete = async (id: number) => {
+        if (!confirm('Bạn có chắc muốn xoá chương trình khuyến mãi này?')) return;
+        if (sessionStatus !== 'authenticated' || !session?.accessToken) return;
+        try {
+            await fetch(`${API_URL}/api/promotion-orders/${id}`, {
+                method: 'DELETE',
+                headers: { Authorization: `Bearer ${session.accessToken}` },
+            });
+            // Cập nhật local state
+            setPromotions(prev => prev.filter(p => p.promotionProgramId !== id));
+            alert('🗑️ Đã xoá thành công');
+        } catch (err) {
+            console.error(err);
+            alert('Không thể xoá. Vui lòng thử lại.');
+        }
+    };
+
+    const handleStatusChange = async (id: number) => {
+        if (sessionStatus !== 'authenticated' || !session?.accessToken) return;
+        try {
+            await fetch(`${API_URL}/api/promotion-orders/update-status/${id}`, {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${session.accessToken}` },
+            });
+            // Cập nhật local state
+            setPromotions(prev => prev.map(p => 
+                p.promotionProgramId === id 
+                    ? { ...p, isActive: !p.isActive }
+                    : p
+            ));
+            alert('✅ Đã thay đổi trạng thái thành công');
+        } catch (err) {
+            console.error(err);
+            alert('Không thể thay đổi trạng thái. Vui lòng thử lại.');
+        }
+    };
+
+    const loadData = useCallback(async () => {
+        if (sessionStatus !== 'authenticated') return;
+        const token = session?.accessToken;
+        if (!token) return;
+
+        setLoading(true);
+        try {
+            const page = currentPage - 1; // API sử dụng zero-based indexing
+            const res = await fetch(`${API_URL}/api/promotion-orders?page=${page}&size=${itemsPerPage}`, {
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            
+            if (!res.ok) {
+                throw new Error(`HTTP error! status: ${res.status}`);
+            }
+            
+            const data: APIResponse = await res.json();
+            
+            if (data.data?.content) {
+                setPromotions(data.data.content);
+                setTotalPages(data.data.totalPages);
+            } else if (data.content) {
+                setPromotions(data.content);
+                setTotalPages(1);
+            } else {
+                setPromotions([]);
+                setTotalPages(1);
+            }
+        } catch (e) {
+            console.error(e);
+            alert('Lỗi khi tải dữ liệu khuyến mãi theo hóa đơn.');
+            setPromotions([]);
+        } finally {
+            setLoading(false);
+        }
+    }, [session, sessionStatus, API_URL, currentPage]);
+
+    useEffect(() => {
+        loadData();
+    }, [loadData]);
+
+    // Tự động về trang 1 khi filter thay đổi
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [filters]);
+
+    const formatDateTime = (s: string) => {
+        const d = new Date(s);
+        return new Intl.DateTimeFormat('vi-VN', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+        }).format(d);
+    };
+
+    // **ÁP DỤNG BỘ LỌC TẠI ĐÂY**
+    const filteredPromotions = useMemo(() => {
+        return promotions.filter(promo => {
+            // Lọc theo từ khóa
+            const keywordMatch = filters.keyword
+                ? promo.promotionName.toLowerCase().includes(filters.keyword.toLowerCase()) ||
+                  promo.promotionCode.toLowerCase().includes(filters.keyword.toLowerCase())
+                : true;
+
+            // Lọc theo trạng thái
+            const statusMatch = (() => {
+                if (!filters.status) return true; // Không lọc nếu không chọn
+                const now = new Date();
+                const withinDate = now >= new Date(promo.startDate) && now <= new Date(promo.endDate);
+                const beforeStart = now < new Date(promo.startDate);
+
+                const statusKey = !promo.isActive && promo.isActive !== undefined
+                    ? 'inactive'
+                    : withinDate
+                        ? 'active'
+                        : beforeStart
+                            ? 'upcoming'
+                            : 'ended';
+
+                return filters.status === statusKey;
+            })();
+
+            return keywordMatch && statusMatch;
+        });
+    }, [promotions, filters]);
+
+    const handleResetFilters = () => {
+        setFilters({ keyword: '', status: '' });
+        setCurrentPage(1);
+    };
+
+    return (
+        <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+            <div className="flex items-center justify-between mb-4">
+                <h2 className="text-xl font-semibold text-gray-800">Danh sách Khuyến mãi theo Hóa đơn</h2>
+                <div className="flex items-center gap-3">
+                    <Link
+                        href="/admin/promotion_order/create"
+                        className="bg-orange-500 text-white px-4 py-2 rounded hover:bg-orange-600 text-sm font-medium"
+                    >
+                        + THÊM MỚI
+                    </Link>
+                </div>
+            </div>
+
+            <div className="bg-white rounded border p-4 shadow-sm">
+                <h3 className="font-medium text-gray-800 mb-3">Bộ lọc tìm kiếm</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+                    <input
+                        type="text"
+                        placeholder="Tìm theo tên hoặc mã..."
+                        className="border rounded px-3 py-2"
+                        value={filters.keyword}
+                        onChange={e => setFilters({ ...filters, keyword: e.target.value })}
+                    />
+                    <select
+                        className="border rounded px-3 py-2"
+                        value={filters.status}
+                        onChange={e => setFilters({ ...filters, status: e.target.value })}
+                    >
+                        <option value="">Tất cả trạng thái</option>
+                        <option value="active">Đang diễn ra</option>
+                        <option value="upcoming">Sắp diễn ra</option>
+                        <option value="ended">Đã kết thúc</option>
+                        <option value="inactive">Không hoạt động</option>
+                    </select>
+                </div>
+                <div className="mt-4">
+                    <button
+                        onClick={handleResetFilters}
+                        className="bg-gray-200 hover:bg-gray-300 text-gray-700 px-4 py-2 rounded text-sm"
+                    >
+                        Làm mới bộ lọc
+                    </button>
+                </div>
+            </div>
+
+            <div className="overflow-x-auto bg-white shadow border rounded">
+                <table className="min-w-full text-sm text-left border">
+                    <thead className="bg-gray-100 text-gray-700 uppercase text-xs">
+                    <tr>
+                        <th className="px-4 py-3 border">STT</th>
+                        <th className="px-4 py-3 border">Mã KM</th>
+                        <th className="px-4 py-3 border">Tên Chương trình</th>
+                        <th className="px-4 py-3 border">Giá trị giảm</th>
+                        <th className="px-4 py-3 border">Tối thiểu</th>
+                        <th className="px-4 py-3 border">Bắt đầu</th>
+                        <th className="px-4 py-3 border">Kết thúc</th>
+                        <th className="px-4 py-3 border">Trạng thái</th>
+                        <th className="px-4 py-3 border">Hoạt động</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {loading ? (
+                        <tr>
+                            <td colSpan={9} className="px-4 py-8 text-center">
+                                <div className="flex items-center justify-center gap-2">
+                                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600" />
+                                    <span className="text-gray-600">Đang tải dữ liệu...</span>
+                                </div>
+                            </td>
+                        </tr>
+                    ) : filteredPromotions.length === 0 ? (
+                        <tr>
+                            <td colSpan={9} className="px-4 py-8 text-center text-gray-500">
+                                Không có dữ liệu phù hợp
+                            </td>
+                        </tr>
+                    ) : (
+                        filteredPromotions.map((promo, idx) => {
+                            const now = new Date();
+                            const withinDate = now >= new Date(promo.startDate) && now <= new Date(promo.endDate);
+                            const beforeStart = now < new Date(promo.startDate);
+
+                            const statusLabel = !promo.isActive && promo.isActive !== undefined
+                                ? 'Không hoạt động'
+                                : withinDate
+                                    ? 'Đang diễn ra'
+                                    : beforeStart
+                                        ? 'Sắp diễn ra'
+                                        : 'Đã kết thúc';
+                            const badgeClass = (() => {
+                                if (statusLabel === 'Không hoạt động') return 'bg-gray-500';
+                                if (statusLabel === 'Đang diễn ra') return 'bg-green-500';
+                                if (statusLabel === 'Sắp diễn ra') return 'bg-yellow-500';
+                                return 'bg-gray-400';
+                            })();
+
+                            return (
+                                <tr key={promo.promotionProgramId} className="border-b hover:bg-gray-50">
+                                    <td className="px-4 py-2 border text-center">
+                                        {(currentPage - 1) * itemsPerPage + idx + 1}
+                                    </td>
+                                    <td className="px-4 py-2 border font-mono text-xs">
+                                        {promo.promotionCode}
+                                    </td>
+                                    <td className="px-4 py-2 border">
+                                        <div>
+                                            <div className="font-medium">{promo.promotionName}</div>
+                                            {promo.description && (
+                                                <div className="text-xs text-gray-500 mt-1">
+                                                    {promo.description}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </td>
+                                    <td className="px-4 py-2 border text-center">
+                                        {formatDiscount(promo.discountValue, promo.discountType)}
+                                    </td>
+                                    <td className="px-4 py-2 border text-center">
+                                        {formatCurrency(promo.minimumOrderValue)}
+                                    </td>
+                                    <td className="px-4 py-2 border text-center">{formatDateTime(promo.startDate)}</td>
+                                    <td className="px-4 py-2 border text-center">{formatDateTime(promo.endDate)}</td>
+                                    <td className="px-4 py-2 border text-center">
+                                            <span
+                                                className={`text-xs px-2 py-1 rounded text-white ${badgeClass}`}
+                                            >
+                                                {statusLabel}
+                                            </span>
+                                    </td>
+                                    <td className="px-4 py-2 border text-center flex items-center justify-center gap-2">
+                                        <Link
+                                            href={`/admin/promotion_order/${promo.promotionProgramId}`}
+                                            className="text-orange-500 hover:text-orange-600 p-1"
+                                            title="Chỉnh sửa"
+                                        >
+                                            <Edit size={16} />
+                                        </Link>
+                                        <button
+                                            onClick={() => handleStatusChange(promo.promotionProgramId)}
+                                            className={`p-1 rounded text-xs ${
+                                                promo.isActive 
+                                                    ? 'text-red-500 hover:text-red-600' 
+                                                    : 'text-green-500 hover:text-green-600'
+                                            }`}
+                                            title={promo.isActive ? 'Tắt hoạt động' : 'Bật hoạt động'}
+                                        >
+                                            {promo.isActive ? '⏸️' : '▶️'}
+                                        </button>
+                                        <button
+                                            onClick={() => handleDelete(promo.promotionProgramId)}
+                                            className="text-red-500 hover:text-red-600 p-1"
+                                            aria-label="Xóa"
+                                        >
+                                            <Trash2 size={16} />
+                                        </button>
+                                    </td>
+                                </tr>
+                            );
+                        })
+                    )}
+                    </tbody>
+                </table>
+
+                {totalPages > 1 && (
+                    <div className="flex items-center justify-center gap-4 py-4">
+                        <button
+                            onClick={() => setCurrentPage(p => Math.max(p - 1, 1))}
+                            disabled={currentPage === 1}
+                            className="px-4 py-1 border rounded disabled:opacity-50"
+                        >
+                            Trước
+                        </button>
+                        <span className="text-sm">
+                            Trang {currentPage} / {totalPages}
+                        </span>
+                        <button
+                            onClick={() => setCurrentPage(p => Math.min(p + 1, totalPages))}
+                            disabled={currentPage === totalPages}
+                            className="px-4 py-1 border rounded disabled:opacity-50"
+                        >
+                            Sau
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/fontend/components/Slidebar.tsx
+++ b/fontend/components/Slidebar.tsx
@@ -44,6 +44,7 @@ const menuItems: MenuItem[] = [
     },
     { href: "/admin/promotion_management/vouchers", icon: <Percent size={18} />, label: "Khuyến mãi" },
     { href: "/admin/promotion_products", icon: <Percent size={18} />, label: "Đợt giảm giá" },
+    { href: "/admin/promotion_order", icon: <Percent size={18} />, label: "Giảm giá theo hóa đơn" },
     { href: "/admin/return_management", icon: <RotateCcw size={18} />, label: "Trả hàng" },
     { href: "/admin/account_management", icon: <User size={18} />, label: "Tài khoản" },
 ];


### PR DESCRIPTION
Introduces new pages for listing, creating, and editing promotion orders under /admin/promotion_order. Updates the sidebar to include a link to 'Giảm giá theo hóa đơn' for easier navigation. These changes enable full CRUD operations for promotion orders in the admin interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive admin interface for managing promotion orders, including listing, filtering, editing, creating, and deleting promotions.
  * Added detailed forms for creating and editing promotion orders with client-side validation, user feedback, and loading states.
  * Enabled status toggling and immediate updates for promotion orders directly from the management page.
  * Added a new sidebar menu item for easy navigation to the promotion order management section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->