### PR TITLE
Refactor admin statistics page and update sidebar links

### DIFF
--- a/fontend/app/admin/page.tsx
+++ b/fontend/app/admin/page.tsx
@@ -491,7 +491,7 @@ export default function AdminDashboard() {
             {/* Promotion Insights Section */}
             {!promotionLoading && promotionStats.totalPromotions > 0 && (
                 <div className="mb-8">
-                    <h2 className="text-xl font-bold text-gray-800 dark:text-white mb-4">📈 Thống kê Khuyến mãi chi tiết</h2>
+                    <h2 className="text-xl font-bold text-gray-800 dark:text-white mb-4">📈Khuyến mãi chi tiết</h2>
                     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
                         <Card className="shadow-md bg-gradient-to-br from-blue-50 to-cyan-50 border-l-4 border-blue-500">
                             <CardHeader className="pb-2">
@@ -722,10 +722,6 @@ export default function AdminDashboard() {
                     </div>
                 </div>
             )}
-
-            <div className="grid grid-cols-1 md:grid-cols-1 gap-6">
-                <StatisticsByDay/>
-            </div>
         </div>
     );
 }

--- a/fontend/app/admin/statistics/page.tsx
+++ b/fontend/app/admin/statistics/page.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import StatisticsByDay from "@/components/statistics/StatisticsByDay";
+
+export default function page() {
+    return (
+        <div>
+            <StatisticsByDay/>
+        </div>
+    );
+}

--- a/fontend/components/Slidebar.tsx
+++ b/fontend/components/Slidebar.tsx
@@ -23,7 +23,7 @@ interface MenuItem {
     children?: MenuItem[];
 }
 const menuItems: MenuItem[] = [
-    { href: "/admin", icon: <LayoutDashboard size={18} />, label: "Thống kê" },
+    { href: "/admin/statistics", icon: <LayoutDashboard size={18} />, label: "Thống kê" },
     { href: "/staff/officesales", icon: <Store size={18} />, label: "Bán hàng tại quầy" },
     { href: "/admin/order/officesales", icon: <FileText size={18} />, label: "Hóa đơn" },
     {
@@ -56,7 +56,7 @@ export default function Sidebar() {
     return (
         <aside className="w-64 min-h-screen bg-white dark:bg-gray-900 shadow-md border-r border-gray-200 dark:border-gray-800 flex flex-col">
             {/* Logo SneakPeak */}
-            <Link href={'/'} className="flex items-center gap-3 px-6 py-5 border-b border-gray-100 dark:border-gray-700">
+            <Link href={'/admin'} className="flex items-center gap-3 px-6 py-5 border-b border-gray-100 dark:border-gray-700">
                 <Image src="/images/logo.png" alt="SneakPeak Logo" width={32} height={32} />
                 <span className="text-xl font-bold text-orange-600">SneakPeak</span>
             </Link>

--- a/fontend/components/statistics/StatisticsByDay.tsx
+++ b/fontend/components/statistics/StatisticsByDay.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useState, useEffect, useMemo, useCallback } from "react";
 import {
   Card,

--- a/fontend/hooks/useRevenue.ts
+++ b/fontend/hooks/useRevenue.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { useState, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { RevenueData, ProductRevenueDetail, RevenueApiParams } from "@/types/revenue";


### PR DESCRIPTION
Moved the daily statistics component to a dedicated /admin/statistics page and updated the sidebar to link to this new route. Adjusted the admin dashboard to remove the embedded statistics section. Added 'use client' directive to relevant components and hooks for client-side rendering.