### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/fontend/components/home/FeaturedProductCard.tsx
+++ b/fontend/components/home/FeaturedProductCard.tsx
@@ -182,9 +182,26 @@ const   FeaturedProductCard = () => {
     // Kiểm tra xem ảnh có phải từ Cloudinary không
     const isCloudinaryImage = (imageUrl: string) => {
         if (!imageUrl) return false
-        return imageUrl.includes('cloudinary.com') || 
-               imageUrl.includes('res.cloudinary.com') ||
-               (!imageUrl.startsWith('http') && !imageUrl.startsWith('/'))
+        // Handle absolute URLs
+        if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
+            try {
+                const host = new URL(imageUrl).host.toLowerCase();
+                // Accept exactly res.cloudinary.com and *.res.cloudinary.com
+                if (host === 'res.cloudinary.com' || host.endsWith('.res.cloudinary.com')) {
+                    return true;
+                }
+                // Optionally handle other official cloudinary subdomains/set as needed
+                return false;
+            } catch {
+                return false;
+            }
+        }
+        // Handle relative and protocol-less paths (like Cloudinary's public ID format)
+        if (!imageUrl.startsWith('http') && !imageUrl.startsWith('/')) {
+            // Not a web URL, so treat as Cloudinary image string or path
+            return true;
+        }
+        return false;
     }
 
     return (


### PR DESCRIPTION
Potential fix for [https://github.com/nongtiensonpro/Yellow_Cat_Web/security/code-scanning/9](https://github.com/nongtiensonpro/Yellow_Cat_Web/security/code-scanning/9)

To fix this issue, the function `isCloudinaryImage` should parse the input `imageUrl` (using the WHATWG `URL` class, which is built-in in Node.js and available in browsers) and inspect the `.host` rather than relying on substring search. The function should explicitly check if the host is exactly `'cloudinary.com'`, a recognized Cloudinary subdomain, or matches patterns used by Cloudinary (`res.cloudinary.com`). For local URLs (relative or absolute paths), the function should recognize these as non-Cloudinary images as before. 

You need to:
- Import or use the global `URL` class.
- Update `isCloudinaryImage` to parse the URL when `imageUrl` starts with http(s), extracting the host and matching allowed Cloudinary hosts.
- Keep the existing handling of local/relative images.
- Make sure the change is isolated and does not affect other logic.

All changes occur inside `fontend/components/home/FeaturedProductCard.tsx`, around lines 183–188.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image source validation for product cards to only accept legitimate Cloudinary images, reducing broken thumbnails and loading errors.
  - Safer handling of invalid or malformed URLs to prevent unexpected failures.
  - More accurate detection of non-URL Cloudinary identifiers ensures expected images render consistently.
  - Eliminates false positives from non-Cloudinary domains, improving overall image reliability in the home view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->